### PR TITLE
Fix spurious .pid file error in linux-sysvinit

### DIFF
--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -36,6 +36,7 @@ ulimit -n 8192
 
 start() {
     $USERBIND $DAEMON
+    touch $LOGFILE && chown $DAEMONUSER $LOGFILE
     start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE \
         --background --chuid $DAEMONUSER --oknodo --exec $DAEMON -- $DAEMONOPTS
 }

--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -20,7 +20,7 @@ DAEMONUSER=www-data
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/var/log/$NAME.log
 CONFIGFILE=/etc/caddy/Caddyfile
-DAEMONOPTS="-agree=true -pidfile=$PIDFILE -log=$LOGFILE -conf=$CONFIGFILE"
+DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"
 
 USERBIND="setcap cap_net_bind_service=+ep"
 STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"


### PR DESCRIPTION
The start-stop-daemon and writes the file as root and the DAEMONUSER that caddy runs as does not manage the .pid file. This change eliminates the `[ERROR] Could not write pidfile: open /var/run/caddy.pid: permission denied` from caddy.log.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

This fixes a spurious error in the /var/log/caddy.log file when using the dist/init/linux-sysvinit/caddy script.

### 2. Please link to the relevant issues.

None

### 3. Which documentation changes (if any) need to be made because of this PR?

None

### 4. Checklist

- [N/A] I have written tests and verified that they fail without my change
- [N/A] I have squashed any insignificant commits
- [N/A] This change has comments for package types, values, functions, and non-obvious lines of code
- [N/A] I am willing to help maintain this change if there are issues with it later
